### PR TITLE
fix: remove RUSTFLAGS edition override causing Docker build failure

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,9 +11,6 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Enable edition 2024 feature
-ENV RUSTFLAGS="--edition=2024"
-
 # Copy manifests first for dependency caching
 # Note: Dockerfile is in backend/, but build context is repo root
 COPY backend/Cargo.toml backend/Cargo.lock* ./


### PR DESCRIPTION
## Summary

- Removes `ENV RUSTFLAGS="--edition=2024"` from Dockerfile that caused Docker build failure
- Fixes error: `Option 'edition' given more than once`

## Problem

The Dockerfile was setting `RUSTFLAGS="--edition=2024"` globally, which gets appended to **all** rustc invocations including dependencies. Dependencies like `proc-macro2`, `libc`, `cfg-if` etc. have their own editions (2018/2021) declared in their Cargo.toml. This caused rustc to receive:

```
rustc ... --edition=2018 ... --edition=2024
```

Resulting in the build failure.

## Solution

Remove the global RUSTFLAGS override. The edition is already correctly declared in `backend/Cargo.toml` as `edition = "2024"`. Cargo automatically handles passing the correct edition to each crate based on its own manifest.

## Related

Fixes build failure from PR #16